### PR TITLE
Make formatting consistent

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,9 @@
 Language: Cpp
 BasedOnStyle: Google
 ColumnLimit: 80
+DerivePointerAlignment: false
+PointerAlignment: Left
+IncludeBlocks: Preserve
 ---
 Language: Proto
 BasedOnStyle: Google

--- a/include/voxblox_ground_truth/common.h
+++ b/include/voxblox_ground_truth/common.h
@@ -31,7 +31,7 @@ struct TriangularFaceVertexCoordinates {
 struct AABB {
   Point min = {INFINITY, INFINITY, INFINITY};
   Point max = {-INFINITY, -INFINITY, -INFINITY};
-  static AABB fromPoints(const Point &a, const Point &b, const Point &c) {
+  static AABB fromPoints(const Point& a, const Point& b, const Point& c) {
     AABB aabb;
     aabb.min = a.cwiseMin(b.cwiseMin(c));
     aabb.max = a.cwiseMax(b.cwiseMax(c));
@@ -39,8 +39,9 @@ struct AABB {
   }
 };
 
-inline bool visualizeIntersectionCount(
-    const IntersectionVoxel& voxel, const Point& /*coord*/, double* intensity) {
+inline bool visualizeIntersectionCount(const IntersectionVoxel& voxel,
+                                       const Point& /*coord*/,
+                                       double* intensity) {
   CHECK_NOTNULL(intensity);
   if (voxel.count > 0) {
     *intensity = voxel.count;

--- a/include/voxblox_ground_truth/common.h
+++ b/include/voxblox_ground_truth/common.h
@@ -1,8 +1,8 @@
 #ifndef VOXBLOX_GROUND_TRUTH_COMMON_H_
 #define VOXBLOX_GROUND_TRUTH_COMMON_H_
 
-#include <glog/logging.h>
 #include <Eigen/StdVector>
+#include <glog/logging.h>
 
 typedef Eigen::Vector3f Point;
 typedef Eigen::Vector2f Point2D;

--- a/include/voxblox_ground_truth/sdf_creator.h
+++ b/include/voxblox_ground_truth/sdf_creator.h
@@ -2,6 +2,7 @@
 #define VOXBLOX_GROUND_TRUTH_SDF_CREATOR_H_
 
 #include <voxblox/core/tsdf_map.h>
+
 #include "voxblox_ground_truth/common.h"
 
 namespace voxblox_ground_truth {

--- a/include/voxblox_ground_truth/sdf_creator.h
+++ b/include/voxblox_ground_truth/sdf_creator.h
@@ -17,10 +17,10 @@ class SdfCreator {
   explicit SdfCreator(voxblox::TsdfMap::Config map_config);
 
   void integrateTriangle(
-      const TriangularFaceVertexCoordinates &vertex_coordinates);
+      const TriangularFaceVertexCoordinates& vertex_coordinates);
 
-  const voxblox::TsdfMap &getTsdfMap();
-  const voxblox::Layer<IntersectionVoxel> &getIntersectionLayer() {
+  const voxblox::TsdfMap& getTsdfMap();
+  const voxblox::Layer<IntersectionVoxel>& getIntersectionLayer() {
     return intersection_layer_;
   }
 
@@ -38,8 +38,8 @@ class SdfCreator {
  private:
   bool signs_up_to_date_;
   void updateSigns();
-  void getAABBIndices(GlobalIndex* global_voxel_index_min, GlobalIndex* global_voxel_index_max) const;
-
+  void getAABBIndices(GlobalIndex* global_voxel_index_min,
+                      GlobalIndex* global_voxel_index_max) const;
 
   voxblox::TsdfMap tsdf_map_;
   voxblox::Layer<IntersectionVoxel> intersection_layer_;

--- a/include/voxblox_ground_truth/sdf_visualizer.h
+++ b/include/voxblox_ground_truth/sdf_visualizer.h
@@ -8,13 +8,12 @@
 namespace voxblox_ground_truth {
 class SdfVisualizer {
  public:
-  explicit SdfVisualizer(ros::NodeHandle *nh_private);
+  explicit SdfVisualizer(ros::NodeHandle* nh_private);
 
   void publishIntersectionVisuals(
-      const voxblox::Layer<IntersectionVoxel> &intersection_layer);
+      const voxblox::Layer<IntersectionVoxel>& intersection_layer);
 
-  void publishTsdfVisuals(
-      const voxblox::Layer<voxblox::TsdfVoxel> &tsdf_layer);
+  void publishTsdfVisuals(const voxblox::Layer<voxblox::TsdfVoxel>& tsdf_layer);
 
  private:
   ros::Publisher tsdf_map_pub_;

--- a/include/voxblox_ground_truth/sdf_visualizer.h
+++ b/include/voxblox_ground_truth/sdf_visualizer.h
@@ -3,6 +3,7 @@
 
 #include <ros/ros.h>
 #include <voxblox_ros/ptcloud_vis.h>
+
 #include "voxblox_ground_truth/common.h"
 
 namespace voxblox_ground_truth {

--- a/include/voxblox_ground_truth/triangle_geometer.h
+++ b/include/voxblox_ground_truth/triangle_geometer.h
@@ -2,6 +2,7 @@
 #define VOXBLOX_GROUND_TRUTH_TRIANGLE_GEOMETER_H_
 
 #include <utility>
+
 #include "voxblox_ground_truth/common.h"
 
 namespace voxblox_ground_truth {

--- a/include/voxblox_ground_truth/triangle_geometer.h
+++ b/include/voxblox_ground_truth/triangle_geometer.h
@@ -12,17 +12,17 @@ class TriangleGeometer {
 
   AABB getAABB() const;
 
-  float getDistanceToPoint(const Point &point) const;
+  float getDistanceToPoint(const Point& point) const;
 
-  bool getRayIntersection(const Point2D &ray_yz,
-                          Point *barycentric_coordinates) const;
+  bool getRayIntersection(const Point2D& ray_yz,
+                          Point* barycentric_coordinates) const;
 
  private:
   const TriangularFaceVertexCoordinates vertices_;
 
-  int getRelativeOrientation(const Point2D &vertex_one,
-                             const Point2D &vertex_two,
-                             float *twice_signed_area) const;
+  int getRelativeOrientation(const Point2D& vertex_one,
+                             const Point2D& vertex_two,
+                             float* twice_signed_area) const;
 };
 }  // namespace voxblox_ground_truth
 

--- a/include/voxblox_ground_truth/user_interfaces/gazebo_plugin.h
+++ b/include/voxblox_ground_truth/user_interfaces/gazebo_plugin.h
@@ -18,8 +18,8 @@ class VoxbloxGroundTruthPlugin : public WorldPlugin {
 
   void Load(physics::WorldPtr world, sdf::ElementPtr _sdf) override;
 
-  bool serviceCallback(voxblox_msgs::FilePath::Request &request,     // NOLINT
-                       voxblox_msgs::FilePath::Response &response);  // NOLINT
+  bool serviceCallback(voxblox_msgs::FilePath::Request& request,     // NOLINT
+                       voxblox_msgs::FilePath::Response& response);  // NOLINT
 
  private:
   physics::WorldPtr world_;
@@ -30,8 +30,8 @@ class VoxbloxGroundTruthPlugin : public WorldPlugin {
   const std::vector<std::string> mesh_type_names_ = {
       "POINTS", "LINES", "LINESTRIPS", "TRIANGLES", "TRIFANS", "TRISTRIPS"};
 
-  const std::vector<std::string> mesh_file_extensions_ = {
-      ".dae", ".obj", ".mtl"};
+  const std::vector<std::string> mesh_file_extensions_ = {".dae", ".obj",
+                                                          ".mtl"};
 
   voxblox_ground_truth::SdfVisualizer sdf_visualizer_;
 };

--- a/include/voxblox_ground_truth/user_interfaces/gazebo_plugin.h
+++ b/include/voxblox_ground_truth/user_interfaces/gazebo_plugin.h
@@ -1,14 +1,16 @@
 #ifndef VOXBLOX_GROUND_TRUTH_USER_INTERFACES_GAZEBO_PLUGIN_H_
 #define VOXBLOX_GROUND_TRUTH_USER_INTERFACES_GAZEBO_PLUGIN_H_
 
-#include <glog/logging.h>
-#include <ros/ros.h>
-#include <voxblox_msgs/FilePath.h>
+#include <string>
+#include <vector>
+
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/PhysicsTypes.hh>
 #include <gazebo/physics/physics.hh>
-#include <string>
-#include <vector>
+#include <glog/logging.h>
+#include <ros/ros.h>
+#include <voxblox_msgs/FilePath.h>
+
 #include "voxblox_ground_truth/sdf_visualizer.h"
 
 namespace gazebo {

--- a/src/sdf_creator.cpp
+++ b/src/sdf_creator.cpp
@@ -1,8 +1,10 @@
-#include <ros/ros.h>
-#include <voxblox/utils/neighbor_tools.h>
+#include "voxblox_ground_truth/sdf_creator.h"
+
 #include <limits>
 
-#include "voxblox_ground_truth/sdf_creator.h"
+#include <ros/ros.h>
+#include <voxblox/utils/neighbor_tools.h>
+
 #include "voxblox_ground_truth/triangle_geometer.h"
 
 namespace voxblox_ground_truth {

--- a/src/sdf_creator.cpp
+++ b/src/sdf_creator.cpp
@@ -20,7 +20,7 @@ SdfCreator::SdfCreator(voxblox::TsdfMap::Config map_config)
       fill_inside_(true) {}
 
 void SdfCreator::integrateTriangle(
-    const TriangularFaceVertexCoordinates &vertex_coordinates) {
+    const TriangularFaceVertexCoordinates& vertex_coordinates) {
   // Indicate that the computed signs are no longer valid
   signs_up_to_date_ = false;
 
@@ -59,7 +59,7 @@ void SdfCreator::integrateTriangle(
         // Allocate the block and get the voxel
         voxblox::Block<voxblox::TsdfVoxel>::Ptr block_ptr =
             tsdf_map_.getTsdfLayerPtr()->allocateBlockPtrByIndex(block_index);
-        voxblox::TsdfVoxel &voxel =
+        voxblox::TsdfVoxel& voxel =
             block_ptr->getVoxelByVoxelIndex(local_voxel_index);
 
         // Compute distance to triangle
@@ -104,7 +104,7 @@ void SdfCreator::integrateTriangle(
         // Allocate the block and get the voxel
         voxblox::Block<IntersectionVoxel>::Ptr block_ptr =
             intersection_layer_.allocateBlockPtrByIndex(block_index);
-        IntersectionVoxel &intersection_voxel =
+        IntersectionVoxel& intersection_voxel =
             block_ptr->getVoxelByVoxelIndex(local_voxel_index);
 
         // Increase the count of intersections for this grid cell
@@ -114,8 +114,8 @@ void SdfCreator::integrateTriangle(
   }
 }
 
-void SdfCreator::getAABBIndices(GlobalIndex *global_voxel_index_min,
-                                GlobalIndex *global_voxel_index_max) const {
+void SdfCreator::getAABBIndices(GlobalIndex* global_voxel_index_min,
+                                GlobalIndex* global_voxel_index_max) const {
   *global_voxel_index_min =
       GlobalIndex::Constant(std::numeric_limits<LongIndexElement>::max());
   *global_voxel_index_max =
@@ -129,7 +129,7 @@ void SdfCreator::getAABBIndices(GlobalIndex *global_voxel_index_min,
   // Iterate over all allocated blocks in the map
   voxblox::BlockIndexList tsdf_block_list;
   tsdf_map_.getTsdfLayer().getAllAllocatedBlocks(&tsdf_block_list);
-  for (const voxblox::BlockIndex &block_index : tsdf_block_list) {
+  for (const voxblox::BlockIndex& block_index : tsdf_block_list) {
     const GlobalIndex global_voxel_index_in_block_min =
         voxblox::getGlobalVoxelIndexFromBlockAndVoxelIndex(
             block_index, local_voxel_index_min, voxels_per_side_);
@@ -165,7 +165,7 @@ void SdfCreator::updateSigns() {
 
         GlobalIndex global_voxel_index(x, y, z);
 
-        IntersectionVoxel *intersection_voxel =
+        IntersectionVoxel* intersection_voxel =
             intersection_layer_.getVoxelPtrByGlobalIndex(global_voxel_index);
 
         if (intersection_voxel) {
@@ -174,7 +174,7 @@ void SdfCreator::updateSigns() {
 
         if (intersection_count % 2 == fill_inside_) {
           // We're inside the surface
-          voxblox::TsdfVoxel *tsdf_voxel =
+          voxblox::TsdfVoxel* tsdf_voxel =
               tsdf_map_.getTsdfLayerPtr()->getVoxelPtrByGlobalIndex(
                   global_voxel_index);
           if (tsdf_voxel) {
@@ -190,7 +190,7 @@ void SdfCreator::updateSigns() {
   LOG(INFO) << "Computing signs completed.";
 }
 
-const voxblox::TsdfMap &SdfCreator::getTsdfMap() {
+const voxblox::TsdfMap& SdfCreator::getTsdfMap() {
   // Compute the signs, unless they're already up to date
   if (!signs_up_to_date_) {
     updateSigns();
@@ -221,7 +221,7 @@ void SdfCreator::floodfillUnoccupied(FloatingPoint distance_value) {
         }
 
         GlobalIndex global_voxel_index(x, y, z);
-        voxblox::TsdfVoxel *tsdf_voxel =
+        voxblox::TsdfVoxel* tsdf_voxel =
             tsdf_map_.getTsdfLayerPtr()->getVoxelPtrByGlobalIndex(
                 global_voxel_index);
         // If the block doesn't exist, make it.
@@ -240,8 +240,8 @@ void SdfCreator::floodfillUnoccupied(FloatingPoint distance_value) {
           voxblox::Neighborhood<>::getFromGlobalIndex(global_voxel_index,
                                                       &neighbor_indices);
           for (unsigned int idx = 0u; idx < neighbor_indices.cols(); ++idx) {
-            const GlobalIndex &neighbor_index = neighbor_indices.col(idx);
-            voxblox::TsdfVoxel *neighbor_voxel =
+            const GlobalIndex& neighbor_index = neighbor_indices.col(idx);
+            voxblox::TsdfVoxel* neighbor_voxel =
                 tsdf_map_.getTsdfLayerPtr()->getVoxelPtrByGlobalIndex(
                     neighbor_index);
             // One free neighbor is enough to mark this voxel as free.

--- a/src/sdf_visualizer.cpp
+++ b/src/sdf_visualizer.cpp
@@ -1,11 +1,13 @@
 #include "voxblox_ground_truth/sdf_visualizer.h"
 
 namespace voxblox_ground_truth {
-SdfVisualizer::SdfVisualizer(ros::NodeHandle *nh_private) : tsdf_slice_height_(0.0) {
+SdfVisualizer::SdfVisualizer(ros::NodeHandle* nh_private)
+    : tsdf_slice_height_(0.0) {
   CHECK_NOTNULL(nh_private);
 
   // Get parameters.
-  nh_private->param("tsdf_slice_height", tsdf_slice_height_, tsdf_slice_height_);
+  nh_private->param("tsdf_slice_height", tsdf_slice_height_,
+                    tsdf_slice_height_);
 
   // Advertise the topics to visualize the SDF map in Rviz
   tsdf_map_pub_ = nh_private->advertise<pcl::PointCloud<pcl::PointXYZI>>(
@@ -21,7 +23,7 @@ SdfVisualizer::SdfVisualizer(ros::NodeHandle *nh_private) : tsdf_slice_height_(0
 }
 
 void voxblox_ground_truth::SdfVisualizer::publishIntersectionVisuals(
-    const voxblox::Layer<IntersectionVoxel> &intersection_layer) {
+    const voxblox::Layer<IntersectionVoxel>& intersection_layer) {
   LOG(INFO) << "Publishing intersection counts";
   pcl::PointCloud<pcl::PointXYZI> intersection_count_msg;
   intersection_count_msg.header.frame_id = "world";
@@ -31,7 +33,7 @@ void voxblox_ground_truth::SdfVisualizer::publishIntersectionVisuals(
 }
 
 void voxblox_ground_truth::SdfVisualizer::publishTsdfVisuals(
-    const voxblox::Layer<voxblox::TsdfVoxel> &tsdf_layer) {
+    const voxblox::Layer<voxblox::TsdfVoxel>& tsdf_layer) {
   LOG(INFO) << "Publishing TSDF";
   pcl::PointCloud<pcl::PointXYZI> tsdf_map_ptcloud_msg;
   tsdf_map_ptcloud_msg.header.frame_id = "world";
@@ -49,9 +51,8 @@ void voxblox_ground_truth::SdfVisualizer::publishTsdfVisuals(
   LOG(INFO) << "Publishing TSDF slice";
   pcl::PointCloud<pcl::PointXYZI> tsdf_slice_ptcloud_msg;
   tsdf_slice_ptcloud_msg.header.frame_id = "world";
-  voxblox::createDistancePointcloudFromTsdfLayerSlice(tsdf_layer,
-                                                      2, tsdf_slice_height_,
-                                                      &tsdf_slice_ptcloud_msg);
+  voxblox::createDistancePointcloudFromTsdfLayerSlice(
+      tsdf_layer, 2, tsdf_slice_height_, &tsdf_slice_ptcloud_msg);
   tsdf_slice_pub_.publish(tsdf_slice_ptcloud_msg);
 }
 }  // namespace voxblox_ground_truth

--- a/src/triangle_geometer.cpp
+++ b/src/triangle_geometer.cpp
@@ -3,7 +3,7 @@
 namespace voxblox_ground_truth {
 // This function is heavily based on the example on page 141 of:
 // "Real-time collision detection" by Christer Ericson
-float TriangleGeometer::getDistanceToPoint(const Point &point) const {
+float TriangleGeometer::getDistanceToPoint(const Point& point) const {
   using Vector = Point;
 
   // Check if the point is in the region outside A
@@ -58,8 +58,8 @@ float TriangleGeometer::getDistanceToPoint(const Point &point) const {
   if (va <= 0.0f && (d4 - d3) >= 0.0f && (d5 - d6) >= 0.0f) {
     const float w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
     // The barycentric coordinates are (0,1-w,w)
-    const Point closest_pt = vertices_.vertex_b
-                           + w * (vertices_.vertex_c - vertices_.vertex_b);
+    const Point closest_pt =
+        vertices_.vertex_b + w * (vertices_.vertex_c - vertices_.vertex_b);
     return (closest_pt - point).norm();
   }
 
@@ -72,16 +72,13 @@ float TriangleGeometer::getDistanceToPoint(const Point &point) const {
   return (closest_pt - point).norm();
 }
 
-
 AABB TriangleGeometer::getAABB() const {
-  return AABB::fromPoints(vertices_.vertex_a,
-                          vertices_.vertex_b,
+  return AABB::fromPoints(vertices_.vertex_a, vertices_.vertex_b,
                           vertices_.vertex_c);
 }
 
-bool TriangleGeometer::getRayIntersection(const Point2D &ray_yz,
-                                          Point *barycentric_coordinates)
-                                          const {
+bool TriangleGeometer::getRayIntersection(
+    const Point2D& ray_yz, Point* barycentric_coordinates) const {
   CHECK_NOTNULL(barycentric_coordinates);
 
   // Express the vertices A, B and C relative to the point
@@ -94,8 +91,7 @@ bool TriangleGeometer::getRayIntersection(const Point2D &ray_yz,
   //       areas. After being normalized, these correspond to the barycentric
   //       coordinates (see the end of this method).
   const int sign_a =
-      getRelativeOrientation(vertex_b_relative,
-                             vertex_c_relative,
+      getRelativeOrientation(vertex_b_relative, vertex_c_relative,
                              &barycentric_coordinates->operator[](0));
   // If the relative orientation is zero, vertices B and C must be equal.
   // This would mean that the triangle has no surface area and the ray therefore
@@ -104,8 +100,7 @@ bool TriangleGeometer::getRayIntersection(const Point2D &ray_yz,
 
   // Check the orientation of C relative to A
   const int sign_b =
-      getRelativeOrientation(vertex_c_relative,
-                             vertex_a_relative,
+      getRelativeOrientation(vertex_c_relative, vertex_a_relative,
                              &barycentric_coordinates->operator[](1));
   // If the signs differ, the solution to the intersection equation does not lie
   // inside the triangle (i.e. the ray does not intersect the triangle)
@@ -113,8 +108,7 @@ bool TriangleGeometer::getRayIntersection(const Point2D &ray_yz,
 
   // Check the orientation of A relative to B
   const int sign_c =
-      getRelativeOrientation(vertex_a_relative,
-                             vertex_b_relative,
+      getRelativeOrientation(vertex_a_relative, vertex_b_relative,
                              &barycentric_coordinates->operator[](2));
   // If the signs differ, the solution to the intersection equation does not lie
   // inside the triangle (i.e. the ray does not intersect the triangle)
@@ -133,9 +127,9 @@ bool TriangleGeometer::getRayIntersection(const Point2D &ray_yz,
   return true;
 }
 
-int TriangleGeometer::getRelativeOrientation(const Point2D &vertex_one,
-                                             const Point2D &vertex_two,
-                                             float *twice_signed_area) const {
+int TriangleGeometer::getRelativeOrientation(const Point2D& vertex_one,
+                                             const Point2D& vertex_two,
+                                             float* twice_signed_area) const {
   CHECK_NOTNULL(twice_signed_area);
 
   // Compute the signed area (scaled by factor 2, but we don't care)

--- a/src/user_interfaces/gazebo_plugin.cpp
+++ b/src/user_interfaces/gazebo_plugin.cpp
@@ -6,8 +6,7 @@ namespace gazebo {
 GZ_REGISTER_WORLD_PLUGIN(VoxbloxGroundTruthPlugin)
 
 VoxbloxGroundTruthPlugin::VoxbloxGroundTruthPlugin()
-    : WorldPlugin(), nh_private_("~"), sdf_visualizer_(&nh_private_) {
-}
+    : WorldPlugin(), nh_private_("~"), sdf_visualizer_(&nh_private_) {}
 
 void VoxbloxGroundTruthPlugin::Load(physics::WorldPtr world,
                                     sdf::ElementPtr _sdf) {
@@ -21,14 +20,14 @@ void VoxbloxGroundTruthPlugin::Load(physics::WorldPtr world,
 }
 
 bool VoxbloxGroundTruthPlugin::serviceCallback(
-    voxblox_msgs::FilePath::Request &request,
-    voxblox_msgs::FilePath::Response &response) {
+    voxblox_msgs::FilePath::Request& request,
+    voxblox_msgs::FilePath::Response& response) {
   // Read the voxel size from ROS params
   CHECK(nh_private_.getParam("/voxblox_ground_truth/voxel_size", voxel_size_))
       << "ROS param /voxblox_ground_truth/voxel_size must be set.";
 
   // Instantiate a Gazebo mesh manager
-  common::MeshManager *mesh_manager = common::MeshManager::Instance();
+  common::MeshManager* mesh_manager = common::MeshManager::Instance();
   CHECK_NOTNULL(mesh_manager);
 
   // Instantiate the ground truth SDF creator
@@ -37,13 +36,13 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
   voxblox_ground_truth::SdfCreator sdf_creator(map_config);
 
   // Iterate over all collision geometries
-# if GAZEBO_MAJOR_VERSION > 8
-  for (const physics::ModelPtr &model : world_->Models()) {
-# else
-  for (const physics::ModelPtr &model : world_->GetModels()) {
+#if GAZEBO_MAJOR_VERSION > 8
+  for (const physics::ModelPtr& model : world_->Models()) {
+#else
+  for (const physics::ModelPtr& model : world_->GetModels()) {
 #endif
-    for (const physics::LinkPtr &link : model->GetLinks()) {
-      for (const physics::CollisionPtr &collision : link->GetCollisions()) {
+    for (const physics::LinkPtr& link : model->GetLinks()) {
+      for (const physics::CollisionPtr& collision : link->GetCollisions()) {
         LOG(INFO) << "Processing '" << collision->GetScopedName(true) << "'";
 
         // Convert the geometry shape to a proto message
@@ -63,7 +62,6 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
           if (geometry_type_str == "box" || geometry_type_str == "cylinder" ||
               geometry_type_str == "sphere" || geometry_type_str == "plane" ||
               geometry_type_str == "mesh") {
-
             if (mesh_manager) {
               const common::Mesh* mesh_ptr;
               std::string mesh_name;
@@ -73,12 +71,12 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
                 LOG(INFO) << "Attempting to load mesh " << mesh_base_name;
                 // extracting file name
                 size_t idx = mesh_base_name.find('.');
-                mesh_base_name.erase(
-                    mesh_base_name.begin() + idx, mesh_base_name.end());
+                mesh_base_name.erase(mesh_base_name.begin() + idx,
+                                     mesh_base_name.end());
                 const std::string prefix = "file://";
                 size_t idx_prefix = mesh_base_name.find(prefix);
-                if (idx_prefix < mesh_base_name.size()
-                    && mesh_base_name.size() > prefix.size()) {
+                if (idx_prefix < mesh_base_name.size() &&
+                    mesh_base_name.size() > prefix.size()) {
                   mesh_base_name.erase(mesh_base_name.begin(),
                                        mesh_base_name.begin() + prefix.size());
                 }
@@ -87,12 +85,12 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
                   mesh_name = mesh_base_name + object_type;
                   mesh_ptr = mesh_manager->Load(mesh_name);
                   if (mesh_ptr) {
-                    LOG(INFO) << "- Loading file \"" << mesh_name
-                              << "\" successful.";
+                    LOG(INFO)
+                        << "- Loading file \"" << mesh_name << "\" successful.";
                     break;
                   } else {
-                    LOG(INFO) << "- Loading mesh \"" << mesh_name
-                              << "\" failed.";
+                    LOG(INFO)
+                        << "- Loading mesh \"" << mesh_name << "\" failed.";
                   }
                 }
                 if (!mesh_ptr) {
@@ -106,8 +104,8 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
               }
 
               if (!mesh_ptr) {
-                LOG(WARNING) << "Could not get pointer to mesh '" << mesh_name
-                             << "'";
+                LOG(WARNING)
+                    << "Could not get pointer to mesh '" << mesh_name << "'";
                 return false;
               }
 
@@ -151,18 +149,18 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
                   geometry_size = collision->GetShape()->Scale();
                   LOG(INFO) << "Scale: shape_scale " << geometry_size;
                 } else {
-                  LOG(ERROR) << "Could not get geometry size of "  << geometry_type_str;
+                  LOG(ERROR)
+                      << "Could not get geometry size of " << geometry_type_str;
                   continue;
                 }
 
                 // Scale the mesh and transform it into world frame
-# if GAZEBO_MAJOR_VERSION > 8
-                const ignition::math::Pose3d transform =
-                    collision->WorldPose();
-# else
+#if GAZEBO_MAJOR_VERSION > 8
+                const ignition::math::Pose3d transform = collision->WorldPose();
+#else
                 const ignition::math::Pose3d transform =
                     collision->GetWorldPose().Ign();
-# endif
+#endif
                 for (unsigned int vertex_i = 0;
                      vertex_i < submesh.GetVertexCount(); vertex_i++) {
                   // Create a copy of the vertex s.t. it can be manipulated
@@ -235,13 +233,12 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
   // Optionally floodfill unoccupied space.
   bool floodfill_unoccupied = false;
   nh_private_.param("floodfill_unoccupied", floodfill_unoccupied,
-                   floodfill_unoccupied);
+                    floodfill_unoccupied);
   if (floodfill_unoccupied) {
     LOG(INFO) << "Floodfill unoccupied space.";
 
     double distance = 4 * voxel_size_;
-    nh_private_.param("floodfill_distance", distance,
-                      distance);
+    nh_private_.param("floodfill_distance", distance, distance);
     LOG(INFO) << "Floodfill distance: " << distance;
     sdf_creator.floodfillUnoccupied(distance);
   }
@@ -251,8 +248,7 @@ bool VoxbloxGroundTruthPlugin::serviceCallback(
   nh_private_.param("publish_visuals", publish_debug_visuals,
                     publish_debug_visuals);
   if (publish_debug_visuals) {
-    sdf_visualizer_.publishTsdfVisuals(
-        sdf_creator.getTsdfMap().getTsdfLayer());
+    sdf_visualizer_.publishTsdfVisuals(sdf_creator.getTsdfMap().getTsdfLayer());
     sdf_visualizer_.publishIntersectionVisuals(
         sdf_creator.getIntersectionLayer());
   }

--- a/src/user_interfaces/gazebo_plugin.cpp
+++ b/src/user_interfaces/gazebo_plugin.cpp
@@ -1,5 +1,7 @@
 #include "voxblox_ground_truth/user_interfaces/gazebo_plugin.h"
+
 #include <string>
+
 #include "voxblox_ground_truth/sdf_creator.h"
 
 namespace gazebo {

--- a/src/user_interfaces/ply_to_sdf_script.cpp
+++ b/src/user_interfaces/ply_to_sdf_script.cpp
@@ -1,4 +1,3 @@
-#include <pcl/io/ply_io.h>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -6,11 +5,15 @@
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <pcl/io/ply_io.h>
+
 #include "voxblox_ground_truth/common.h"
 #include "voxblox_ground_truth/sdf_creator.h"
 
 // For debugging only
 #include <ros/ros.h>
+
 #include "voxblox_ground_truth/sdf_visualizer.h"
 
 int main(int argc, char* argv[]) {

--- a/src/user_interfaces/ply_to_sdf_script.cpp
+++ b/src/user_interfaces/ply_to_sdf_script.cpp
@@ -13,7 +13,7 @@
 #include <ros/ros.h>
 #include "voxblox_ground_truth/sdf_visualizer.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   using PointcloudMsg = pcl::PointCloud<pcl::PointXYZI>;
   /* Advertise the debugging ROS topic */
   // Register with ROS
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
   // Iterate over all triangles
   size_t triangle_i = 0;
   size_t num_triangles = mesh.polygons.size();
-  for (const pcl::Vertices &polygon : mesh.polygons) {
+  for (const pcl::Vertices& polygon : mesh.polygons) {
     // Ensure that the polygon is a triangle (other meshes are not supported)
     CHECK_EQ(polygon.vertices.size(), 3);
 


### PR DESCRIPTION
This PR introduces no code changes, it only updates the formatting with clang format. The only notable changes are:
- References and pointers are now consistently aligned to the left
- Includes are grouped and reordered according to Google's style guide

Hopefully, this doesn't cause too many conflicts with your code @helenol @gasserl. Let me know if it does. If so we could postpone merging this.