### PR TITLE
Fix offset in ground truth map

### DIFF
--- a/src/sdf_creator.cpp
+++ b/src/sdf_creator.cpp
@@ -66,7 +66,7 @@ void SdfCreator::integrateTriangle(
 
         // Compute distance to triangle
         voxel_origin =
-            voxblox::getOriginPointFromGridIndex(voxel_index, voxel_size_);
+            voxblox::getCenterPointFromGridIndex(voxel_index, voxel_size_);
         float distance = triangle_geometer.getDistanceToPoint(voxel_origin);
 
         // Update voxel if new distance is lower or if it is new


### PR DESCRIPTION
Hey,

currently, the ground truth map generated by this plugin is offset by half of the voxel size compared to the gazebo map. This leads to a systematic error when using this map as part of an evaluation.

The reason this is happening is because instead of using the center of a voxel to compute the distance, the origin is used. This commit fixes this.

Best regards,
Martin